### PR TITLE
Fix github molecules loading of connectors

### DIFF
--- a/src/js/molecules/githubmolecule.js
+++ b/src/js/molecules/githubmolecule.js
@@ -51,7 +51,7 @@ export default class GitHubMolecule extends Molecule {
             //Try to re-establish the connectors in the parent molecule to get the ones that were missed before when this molecule had not yet been fully loaded
             if(typeof this.parent !== 'undefined'){
                 this.parent.savedConnectors.forEach(connector => {
-                    this.parent.placeConnector(JSON.parse(connector))
+                    this.parent.placeConnector(connector)
                 })
             }
             

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -308,7 +308,7 @@ export default class Molecule extends Atom{
         //reload the molecule object to prevent persistence issues
         moleculeObject = moleculeList.filter((molecule) => { return molecule.uniqueID == moleculeID})[0]
             
-        //Place the connectors FIXME: This is being saved into the object twice now that we are saving everything from the main object so the variable name should be changed
+        //Place the connectors
         this.savedConnectors = moleculeObject.allConnectors //Save a copy of the connectors so we can use them later if we want
         this.savedConnectors.forEach(connector => {
             this.placeConnector(connector)


### PR DESCRIPTION
Github molecules were trying to unpack JSON, but we don't store connectors that way anymore
