### PR TITLE
Move camera to fit shape in frame

### DIFF
--- a/src/js/display.js
+++ b/src/js/display.js
@@ -130,8 +130,8 @@ export default class Display {
     zoomCameraToFit(bounds){
         this.controls.reset()
         this.camera.position.x = 0
-        this.camera.position.y = -4*Math.max(...bounds[1])
-        this.camera.position.z = 4*Math.max(...bounds[1])
+        this.camera.position.y = -5*Math.max(...bounds[1])
+        this.camera.position.z = 5*Math.max(...bounds[1])
     }
     
     updateDisplayData(threejsGeometry){

--- a/src/js/display.js
+++ b/src/js/display.js
@@ -127,6 +127,13 @@ export default class Display {
         }
     }
     
+    zoomCameraToFit(bounds){
+        console.log("Zooming to: " + 6*Math.max(...bounds[1]))
+        this.camera.position.x = 4*Math.max(...bounds[1])
+        this.camera.position.y = 4*Math.max(...bounds[1])
+        this.camera.position.z = 4*Math.max(...bounds[1])
+    }
+    
     updateDisplayData(threejsGeometry){
         // Delete any previous dataset in the window.
         for (const { mesh } of this.datasets) {

--- a/src/js/display.js
+++ b/src/js/display.js
@@ -128,10 +128,9 @@ export default class Display {
     }
     
     zoomCameraToFit(bounds){
-        console.log("Zooming to: " + 6*Math.max(...bounds[1]))
         this.controls.reset()
-        this.camera.position.x = 4*Math.max(...bounds[1])
-        this.camera.position.y = 4*Math.max(...bounds[1])
+        this.camera.position.x = 0
+        this.camera.position.y = -4*Math.max(...bounds[1])
         this.camera.position.z = 4*Math.max(...bounds[1])
     }
     

--- a/src/js/display.js
+++ b/src/js/display.js
@@ -129,6 +129,7 @@ export default class Display {
     
     zoomCameraToFit(bounds){
         console.log("Zooming to: " + 6*Math.max(...bounds[1]))
+        this.controls.reset()
         this.camera.position.x = 4*Math.max(...bounds[1])
         this.camera.position.y = 4*Math.max(...bounds[1])
         this.camera.position.z = 4*Math.max(...bounds[1])

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -410,5 +410,15 @@ export default class Molecule extends Atom{
         //Update the connection
         connector.propogate()
     }
+    
+    sendToRender(){
+        super.sendToRender()
+        if(this.topLevel){
+            try{
+                GlobalVariables.display.zoomCameraToFit(this.value.measureBoundingBox())
+            }
+            catch(err){}
+        }
+    }
 }
 

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -413,11 +413,8 @@ export default class Molecule extends Atom{
     
     sendToRender(){
         super.sendToRender()
-        if(this.topLevel){
-            try{
-                GlobalVariables.display.zoomCameraToFit(this.value.measureBoundingBox())
-            }
-            catch(err){}
+        if(this.topLevel && this.value.measureBoundingBox){
+            GlobalVariables.display.zoomCameraToFit(this.value.measureBoundingBox())
         }
     }
 }


### PR DESCRIPTION
Background click on molecules will now pull the camera back to fit the entire molecule in the camera frame. This also happens when a file is first loadeded