### PR TITLE
Fix input default value

### DIFF
--- a/src/js/molecules/input.js
+++ b/src/js/molecules/input.js
@@ -7,7 +7,7 @@ export default class Input extends Atom {
         super (values)
         
         this.name = 'Input' + GlobalVariables.generateUniqueID()
-        this.value = ''
+        this.value = 10
         this.type = 'input'
         this.atomType = 'Input'
         this.height = 16


### PR DESCRIPTION
Inputs were breaking on creation because the default value was ""