### PR TITLE
Fix how atoms spawn when creating a new project

### DIFF
--- a/src/js/display.js
+++ b/src/js/display.js
@@ -335,6 +335,10 @@ export default class Display {
         planeMaterial.wireframe = true
         planeMaterial.transparent = true 
         planeMaterial.opacity = 0.2
+        /** 
+         * The grid which displays under the part.
+         * @type {object}
+         */
         this.plane = new THREE.Mesh( planeGeometry, planeMaterial )
         this.plane.receiveShadow = true
         this.scene.add( this.plane )   

--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -480,6 +480,7 @@ export default function GitHubModule(){
             })
         })
         
+        GlobalVariables.evalLock = false
         GlobalVariables.currentMolecule.backgroundClick()
         
         //Clear and hide the popup

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -428,6 +428,10 @@ export default class Molecule extends Atom{
             //reload the molecule object to prevent persistence issues
             moleculeObject = moleculeList.filter((molecule) => { return molecule.uniqueID == moleculeID})[0]
             //Place the connectors
+            /**
+             * A copy of the connectors attached to this molecule which can be reattached later. Should be redone.
+             * @param {array}
+             */
             this.savedConnectors = moleculeObject.allConnectors //Save a copy of the connectors so we can use them later if we want
             this.savedConnectors.forEach(connector => {
                 this.placeConnector(connector)

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -29,6 +29,11 @@ export default class Output extends Atom {
          */
         this.name = 'Output'
         /**
+         * This atom's value
+         * @type {object}
+         */
+        this.value = null
+        /**
          * This atom's type
          * @type {string}
          */

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -19,11 +19,6 @@ export default class Output extends Atom {
         }
         
         /**
-         * This atom's value
-         * @type {object}
-         */
-        this.value = null
-        /**
          * This atom's type
          * @type {string}
          */
@@ -51,7 +46,7 @@ export default class Output extends Atom {
         
         this.setValues(values)
         
-        this.addIO('input', 'number or geometry', this, 'geometry', '')
+        this.addIO('input', 'number or geometry', this, 'geometry', null)
     }
     
     /**

--- a/test/documentation.js
+++ b/test/documentation.js
@@ -9,7 +9,7 @@ describe('Check Documentation', function() {
             const rawdata = fs.readFileSync('./dist/documentation/coverage.json')
             const coverage = JSON.parse(rawdata)
             const percentageCovered = parseFloat(coverage.coverage)
-            expect(percentageCovered).to.be.above(99)
+            expect(percentageCovered).to.be.above(99.7)
         })
     })
   


### PR DESCRIPTION
There was an issue with when a new project was created the value would set to an empty string instead of null resulting in errors in the console but no bad behavior. The new project was also being created with evalLock = true which was preventing anything from showing up when you click the atoms, although that wasn't creating errors in the console, this fixes both those things