### PR TITLE
Switch circle for diameter

### DIFF
--- a/src/js/molecules/circle.js
+++ b/src/js/molecules/circle.js
@@ -25,7 +25,7 @@ export default class Circle extends Atom {
          */
         this.atomType = 'Circle'
         
-        this.addIO('input', 'radius', this, 'number', 10)
+        this.addIO('input', 'diameter', this, 'number', 10)
         this.addIO('output', 'geometry', this, 'geometry', '')
         
         this.setValues(values)
@@ -36,10 +36,10 @@ export default class Circle extends Atom {
      */ 
     updateValue(){
         try{
-            const circumference  = 3.14*2*this.findIOValue('radius')
+            const circumference  = 3.14*this.findIOValue('diameter')
             const numberOfSegments = Math.max(parseInt( circumference / GlobalVariables.circleSegmentSize ),5)
             
-            const values = [this.findIOValue('radius'), numberOfSegments]
+            const values = [this.findIOValue('diameter'), numberOfSegments]
             this.basicThreadValueProcessing(values, "circle")
         }catch(err){this.setAlert(err)}
     }


### PR DESCRIPTION
This pull request change the input of circle from radius to diameter. This makes a lot more sense and is the same as rectangle, but it will break all of the existing designs

Please check that your pull request:

- [ ] Passes lint. You can see which parts of your pull request are not passing lint and fix basic errors by running `npm run lint -- --fix` from within the Maslow-Create repo

- [ ] Is documented. You can see which lines need to be documented in your pull request by running the command `npm run doc` from within the Maslow-Create repo and then looking at the generated `dist\documentation\coverage.json` file.

Thanks for helping to keep the project tidy!
