### PR TITLE
Hide the export to github button

### DIFF
--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -193,7 +193,7 @@ export default class Molecule extends Atom{
         if(!this.topLevel){
             this.createButton(valueList,this,'Go To Parent',this.goToParentMolecule)
             
-            this.createButton(valueList,this,'Export To GitHub', this.exportToGithub)
+            //this.createButton(valueList,this,'Export To GitHub', this.exportToGithub)
         }
         else{ //If we are the top level molecule and not in run mode
             this.createButton(valueList,this,'Load A Different Project',() => {


### PR DESCRIPTION
It isn't working and it has not proved very useful so far. Could be added again at a later date when higher priority things have been done