### PR TITLE
Add an x to close the "load a project" pupup

### DIFF
--- a/dist/maslowCreate.css
+++ b/dist/maslowCreate.css
@@ -133,6 +133,15 @@
   flex-shrink: 2; 
 }
 
+.closeButton{
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    padding: 0;
+    border: none;
+    background: none;
+}
+
 .sideBar {
     flex:2;
     margin: 0px 10px 0px 1%;

--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -89,6 +89,17 @@ export default function GitHubModule(){
         popup.classList.remove('off')
         popup.setAttribute("style", "text-align: center")
         
+        if(GlobalVariables.topLevelMolecule && GlobalVariables.topLevelMolecule.name != "Maslow Create"){ //Only offer a close button if there is a project to go back to
+            var closeButton = document.createElement("button")
+            closeButton.appendChild(document.createTextNode("X"))
+            closeButton.setAttribute("class", "closeButton")
+            closeButton.style.fontSize = "xx-large"
+            closeButton.addEventListener("click", () => {
+                popup.classList.add('off')
+            })
+            popup.appendChild(closeButton)
+        }
+        
         var tabButtons = document.createElement("DIV")
         tabButtons.setAttribute("class", "tab")
         tabButtons.setAttribute("style", "display: inline-block;")


### PR DESCRIPTION
Adds an X to close the "load project" popup in case you open it by accident 
