### PR TITLE
create seperate saving thread worker

### DIFF
--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -544,7 +544,7 @@ export default function GitHubModule(){
             }
             
             const threadCompute = async (values, key) => {
-                return await GlobalVariables.ask({values: values, key: key})
+                return await GlobalVariables.saveWorker({values: values, key: key})
             }
             threadCompute([shape], "stl").then( stlContent => {
                 

--- a/src/js/globalvariables.js
+++ b/src/js/globalvariables.js
@@ -141,6 +141,13 @@ class GlobalVariables{
              */
             this.render = result.ask
         })
+        createService({ webWorker: '../maslowWorker.js', agent }).then(result => {
+            /** 
+             * The worker which is used during the saving process.
+             * @type {object}
+             */
+            this.saveWorker = result.ask
+        })
         
         const math = create(all)
         /** 


### PR DESCRIPTION
Use a new worker thread for saving. With big projects the fact that things can't update during the saving process is a drag, and also slows down the saving process. They should just be separate.

Please check that your pull request:

- [x] Passes lint. You can see which parts of your pull request are not passing lint and fix basic errors by running `npm run lint -- --fix` from within the Maslow-Create repo

- [x] Is documented. You can see which lines need to be documented in your pull request by running the command `npm run doc` from within the Maslow-Create repo and then looking at the generated `dist\documentation\coverage.json` file.

Thanks for helping to keep the project tidy!
