### PR TITLE
Fix and Update how the Bill Of Materials is generated 

### DIFF
--- a/src/js/BOM.js
+++ b/src/js/BOM.js
@@ -63,6 +63,9 @@ export const extractBomTags = async(geometry) => {
             this[bomElement.BOMitemName].costUSD += bomElement.costUSD
         }, Object.create(null))
         
+        //Alphabetize by source
+        compiledArray = compiledArray.sort((a,b) => (a.source > b.source) ? 1 : ((b.source > a.source) ? -1 : 0)) 
+        
         return compiledArray
     }
 }

--- a/src/js/BOM.js
+++ b/src/js/BOM.js
@@ -63,9 +63,6 @@ export const extractBomTags = async(geometry) => {
             this[bomElement.BOMitemName].costUSD += bomElement.costUSD
         }, Object.create(null))
         
-        console.log("Compiled array: ")
-        console.log(compiledArray)
-        
         return compiledArray
     }
 }

--- a/src/js/BOM.js
+++ b/src/js/BOM.js
@@ -1,3 +1,5 @@
+import GlobalVariables from './globalvariables.js'
+
 /**
  * This class defines a BOMEntry object which is used to define one entry in a bill of materials.
  */ 
@@ -38,53 +40,32 @@ export class BOMEntry {
  * Computes and returns an array of BOMEntry objects after looking at the tags of a geometry.
  * @param {object} geometry - The geometry which should be scanned for tags.
  */ 
-export const extractBomTags = (geometry) => {
+export const extractBomTags = async(geometry) => {
     
     var bomItems = []
     
-    const walk = (geometry) => {
-        //Grab any available tags
-        if(geometry.tags){
-            geometry.tags.forEach(tag => {
-                if(tag.substring(0,11) == 'user/{"BOMi'){
-                    bomItems.push(JSON.parse(tag.substring(5)))
-                }
-            })
-        }
+    var result = await GlobalVariables.ask({values: [geometry], key: "getBOM"})
+    
+    if (result != -1 ){
+        bomItems = result.map(JSON.parse)
+        bomItems = bomItems.map(JSON.parse)
         
-        //Walk deeper if there is deeper to go
-        if (geometry.disjointAssembly) {
-            geometry.disjointAssembly.forEach(walk)
-        }
-        else if (geometry.lazyGeometry) {
-            walk(geometry.lazyGeometry)
-        }
-        else if (geometry.geometry) {
-            walk(geometry.geometry)
-        }
-        else{
-            return
-        }
+        //Consolidate similar items into a single item
+        var compiledArray = []
+        bomItems.forEach(function (bomElement) {
+            if (!this[bomElement.BOMitemName]) {
+                this[bomElement.BOMitemName] = new BOMEntry
+                this[bomElement.BOMitemName].BOMitemName = bomElement.BOMitemName
+                this[bomElement.BOMitemName].source = bomElement.source
+                compiledArray.push(this[bomElement.BOMitemName])
+            }
+            this[bomElement.BOMitemName].numberNeeded += bomElement.numberNeeded
+            this[bomElement.BOMitemName].costUSD += bomElement.costUSD
+        }, Object.create(null))
+        
+        console.log("Compiled array: ")
+        console.log(compiledArray)
+        
+        return compiledArray
     }
-    
-    if(geometry != null){
-        walk(geometry)
-    }
-    
-    
-    //Consolidate similar items into a single item
-    var result = []
-    bomItems.forEach(function (bomElement) {
-        if (!this[bomElement.BOMitemName]) {
-            this[bomElement.BOMitemName] = new BOMEntry
-            this[bomElement.BOMitemName].BOMitemName = bomElement.BOMitemName
-            this[bomElement.BOMitemName].source = bomElement.source
-            result.push(this[bomElement.BOMitemName])
-        }
-        this[bomElement.BOMitemName].numberNeeded += bomElement.numberNeeded
-        this[bomElement.BOMitemName].costUSD += bomElement.costUSD
-    }, Object.create(null))
-    
-    
-    return result
 }

--- a/src/js/display.js
+++ b/src/js/display.js
@@ -632,6 +632,8 @@ export default class Display {
             const { tags } = geometry
             if (geometry.assembly) {
                 geometry.assembly.forEach(walk)
+            } else if (geometry.item) {
+                walk(geometry.item);
             } else if (geometry.threejsSegments) {
                 const segments = geometry.threejsSegments
                 const dataset = {}

--- a/src/js/display.js
+++ b/src/js/display.js
@@ -633,7 +633,7 @@ export default class Display {
             if (geometry.assembly) {
                 geometry.assembly.forEach(walk)
             } else if (geometry.item) {
-                walk(geometry.item);
+                walk(geometry.item)
             } else if (geometry.threejsSegments) {
                 const segments = geometry.threejsSegments
                 const dataset = {}

--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -554,40 +554,41 @@ export default function GitHubModule(){
                 threadCompute([shape], "SVG Picture").then(contentSvg => {
                     
                     var bomContent = bomHeader
-                    const bomItems = extractBomTags(GlobalVariables.topLevelMolecule.value)
-                    var totalParts = 0
-                    var totalCost  = 0
-                    bomItems.forEach(item => {
-                        totalParts += item.numberNeeded
-                        totalCost  += item.costUSD
-                        bomContent = bomContent + "\n|" + item.BOMitemName + "|" + item.numberNeeded + "|$" + item.costUSD.toFixed(2) + "|" + item.source + "|"
+                    extractBomTags(GlobalVariables.topLevelMolecule.value).then(bomItems => {
+                        var totalParts = 0
+                        var totalCost  = 0
+                        bomItems.forEach(item => {
+                            totalParts += item.numberNeeded
+                            totalCost  += item.costUSD
+                            bomContent = bomContent + "\n|" + item.BOMitemName + "|" + item.numberNeeded + "|$" + item.costUSD.toFixed(2) + "|" + item.source + "|"
+                        })
+                        bomContent = bomContent + "\n|" + "Total: " + "|" + totalParts + "|$" + totalCost.toFixed(2) + "|" + " " + "|"
+                        bomContent = bomContent+"\n\n 3xCOG MSRP: $" + (3*totalCost).toFixed(2)
+                        
+                        
+                        var readmeContent = readmeHeader + "\n\n" + "# " + currentRepoName + "\n\n![](/project.svg)\n\n"
+                        GlobalVariables.topLevelMolecule.requestReadme().forEach(item => {
+                            readmeContent = readmeContent + item + "\n\n\n"
+                        })
+                        
+                        const projectContent = JSON.stringify(GlobalVariables.topLevelMolecule.serialize(null), null, 4)
+                        
+                        this.createCommit(octokit,{
+                            owner: currentUser,
+                            repo: currentRepoName,
+                            base: 'master', /* optional: defaults to default branch */
+                            changes: {
+                                files: {
+                                    'project.stl': stlContent,
+                                    'project.svg': contentSvg,
+                                    'BillOfMaterials.md': bomContent,
+                                    'README.md': readmeContent,
+                                    'project.maslowcreate': projectContent
+                                },
+                                commit: 'Autosave'
+                            }
+                        })
                     })
-                    bomContent = bomContent + "\n|" + "Total: " + "|" + totalParts + "|$" + totalCost.toFixed(2) + "|" + " " + "|"
-                    bomContent = bomContent+"\n\n 3xCOG MSRP: $" + (3*totalCost).toFixed(2)
-                    
-                    
-                    var readmeContent = readmeHeader + "\n\n" + "# " + currentRepoName + "\n\n![](/project.svg)\n\n"
-                    GlobalVariables.topLevelMolecule.requestReadme().forEach(item => {
-                        readmeContent = readmeContent + item + "\n\n\n"
-                    })
-                    
-                    const projectContent = JSON.stringify(GlobalVariables.topLevelMolecule.serialize(null), null, 4)
-                    
-                    this.createCommit(octokit,{
-                        owner: currentUser,
-                        repo: currentRepoName,
-                        base: 'master', /* optional: defaults to default branch */
-                        changes: {
-                            files: {
-                                'project.stl': stlContent,
-                                'project.svg': contentSvg,
-                                'BillOfMaterials.md': bomContent,
-                                'README.md': readmeContent,
-                                'project.maslowcreate': projectContent
-                            },
-                            commit: 'Autosave'
-                        }
-                    }) 
                 })
             })
         }

--- a/src/js/molecules/BOM.js
+++ b/src/js/molecules/BOM.js
@@ -53,7 +53,7 @@ export default class AddBOMTag extends Atom{
         if(!GlobalVariables.evalLock && this.inputs.every(x => x.ready)){
             try{
                 const values = [this.findIOValue('geometry'), JSON.stringify(this.BOMitem)]
-                this.basicThreadValueProcessing(values, "tag")
+                this.basicThreadValueProcessing(values, "specify")
                 this.clearAlert()
             }catch(err){this.setAlert(err)}
             super.updateValue()

--- a/src/js/molecules/cutlist.js
+++ b/src/js/molecules/cutlist.js
@@ -36,7 +36,7 @@ export default class CutList extends Atom{
     updateValue(){
         try{
             const values = [this.findIOValue('geometry'), "cutList"+GlobalVariables.generateUniqueID()]
-            this.basicThreadValueProcessing(values, "tag")
+            this.basicThreadValueProcessing(values, "specify")
         }catch(err){this.setAlert(err)}
         super.updateValue()
     }

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -249,31 +249,38 @@ export default class Molecule extends Atom{
      */ 
     displaySimpleBOM(list){
         var bomList = []
+        
         if(this.value != null){
-            try{
-                bomList = extractBomTags(this.value)
-            }catch(err){
-                this.setAlert("Unable to read BOM")
+            if(this.topLevel){
+                GlobalVariables.ask({values: [this.value], key: "getBOM"}).then(result => {
+                    if (result != -1 ){
+                        bomList = result.map(JSON.parse)
+                        bomList = bomList.map(JSON.parse)
+                        
+                        if(bomList.length > 0){
+                            console.log("bomlist seen")
+                            list.appendChild(document.createElement('br'))
+                            list.appendChild(document.createElement('br'))
+                            
+                            var div = document.createElement('h3')
+                            div.setAttribute('style','text-align:center;')
+                            list.appendChild(div)
+                            var valueText = document.createTextNode('Bill Of Materials')
+                            div.appendChild(valueText)
+                            
+                            var x = document.createElement('HR')
+                            list.appendChild(x)
+                            
+                            bomList.forEach(bomEntry => {
+                                this.createNonEditableValueListItem(list,bomEntry,'numberNeeded', bomEntry.BOMitemName, false)
+                            })
+                        }
+                        
+                    }else{
+                        console.warn("Unable to compute BOM")
+                    }
+                })
             }
-        }
-        
-        if(bomList.length > 0){
-        
-            list.appendChild(document.createElement('br'))
-            list.appendChild(document.createElement('br'))
-            
-            var div = document.createElement('h3')
-            div.setAttribute('style','text-align:center;')
-            list.appendChild(div)
-            var valueText = document.createTextNode('Bill Of Materials')
-            div.appendChild(valueText)
-            
-            var x = document.createElement('HR')
-            list.appendChild(x)
-            
-            bomList.forEach(bomEntry => {
-                this.createNonEditableValueListItem(list,bomEntry,'numberNeeded', bomEntry.BOMitemName, false)
-            })
         }
     }
 

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -248,40 +248,39 @@ export default class Molecule extends Atom{
      * @param {object} list - The HTML object to append the created element to.
      */ 
     displaySimpleBOM(list){
-        var bomList = []
         
         if(this.value != null){
-            if(this.topLevel){
-                GlobalVariables.ask({values: [this.value], key: "getBOM"}).then(result => {
-                    if (result != -1 ){
-                        bomList = result.map(JSON.parse)
-                        bomList = bomList.map(JSON.parse)
+            try{
+                extractBomTags(this.value).then(result => {
+                    console.log("Extracted list result:")
+                    console.log(result)
+                    
+                    var bomList = result
+                    
+                    if(bomList.length > 0){
+                    
+                        list.appendChild(document.createElement('br'))
+                        list.appendChild(document.createElement('br'))
                         
-                        if(bomList.length > 0){
-                            console.log("bomlist seen")
-                            list.appendChild(document.createElement('br'))
-                            list.appendChild(document.createElement('br'))
-                            
-                            var div = document.createElement('h3')
-                            div.setAttribute('style','text-align:center;')
-                            list.appendChild(div)
-                            var valueText = document.createTextNode('Bill Of Materials')
-                            div.appendChild(valueText)
-                            
-                            var x = document.createElement('HR')
-                            list.appendChild(x)
-                            
-                            bomList.forEach(bomEntry => {
-                                this.createNonEditableValueListItem(list,bomEntry,'numberNeeded', bomEntry.BOMitemName, false)
-                            })
-                        }
+                        var div = document.createElement('h3')
+                        div.setAttribute('style','text-align:center;')
+                        list.appendChild(div)
+                        var valueText = document.createTextNode('Bill Of Materials')
+                        div.appendChild(valueText)
                         
-                    }else{
-                        console.warn("Unable to compute BOM")
+                        var x = document.createElement('HR')
+                        list.appendChild(x)
+                        
+                        bomList.forEach(bomEntry => {
+                            this.createNonEditableValueListItem(list,bomEntry,'numberNeeded', bomEntry.BOMitemName, false)
+                        })
                     }
                 })
+            }catch(err){
+                this.setAlert("Unable to read BOM")
             }
         }
+        
     }
 
     /**

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -251,11 +251,7 @@ export default class Molecule extends Atom{
         
         if(this.value != null){
             try{
-                extractBomTags(this.value).then(result => {
-                    console.log("Extracted list result:")
-                    console.log(result)
-                    
-                    var bomList = result
+                extractBomTags(this.value).then(bomList => {
                     
                     if(bomList.length > 0){
                     

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -308,6 +308,7 @@ export default class Atom {
             this.updateSidebar()
             this.sendToRender()
             clickProcessed = true
+            console.log(this.value)
         }
         else{
             this.color = this.defaultColor

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -308,7 +308,6 @@ export default class Atom {
             this.updateSidebar()
             this.sendToRender()
             clickProcessed = true
-            console.log(this.value)
         }
         else{
             this.color = this.defaultColor


### PR DESCRIPTION
The Bill Of Materials now uses the new toBillOfMaterials function and generates correctly for assemblies with multiple of the same part. The results are now alphabetized by source to keep parts from the same source together.


Please check that your pull request:

- [x] Passes lint. You can see which parts of your pull request are not passing lint and fix basic errors by running `npm run lint -- --fix` from within the Maslow-Create repo

- [x] Is documented. You can see which lines need to be documented in your pull request by running the command `npm run doc` from within the Maslow-Create repo and then looking at the generated `dist\documentation\coverage.json` file.

Thanks for helping to keep the project tidy!
