### PR TITLE
Fix top tab buttons

### DIFF
--- a/dist/maslowCreate.css
+++ b/dist/maslowCreate.css
@@ -359,7 +359,6 @@ input.menu_search:focus {
 .tab button {
     float: left;
     vertical-align: middle;
-    width: 50%;
     border: 0px white solid;
     outline: none;
     cursor: pointer;


### PR DESCRIPTION
The top tabs have been looking pretty funky

![image](https://user-images.githubusercontent.com/9359447/65354891-558aa500-dbf9-11e9-90a2-39ab3aa09ef0.png)

This fixes them, but also affects other places like the search for an atom menu