### PR TITLE
Make atoms with no inputs turn blue while processing

### DIFF
--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -187,10 +187,16 @@ export default class Molecule extends Atom{
         //Run for this molecule
         super.beginPropogation()
         
+        //Catch the corner case where this has no inputs which means it won't be marked as processing by super
+        if(this.inputs.length == 0){
+            this.processing = true
+        }
+        
         // Run for every atom in this molecule
         this.nodesOnTheScreen.forEach(node => {
             node.beginPropogation()
         })
+        
     }
     
     /**


### PR DESCRIPTION
Atoms which are processing turn blue, but there was a corner case where atoms with no inputs were not being triggered to turn blue. This PR fixes that.
