### PR TITLE
Make wireframe check persist properly across molecules

### DIFF
--- a/src/js/display.js
+++ b/src/js/display.js
@@ -82,8 +82,7 @@ export default class Display {
         this.threeMaterial = new THREE.MeshStandardMaterial({
             color: 0x5f6670,
             roughness: 0.65,
-            metalness: 0.40,   
-            wireframe: this.wireDisplay
+            metalness: 0.40
         })
         
         /** 
@@ -501,7 +500,6 @@ export default class Display {
                
         if (this.wireDisplay){
             wireCheck.setAttribute('checked', 'true')
-            this.threeMaterial.wireframe = true
         }
         //wireCheck.setAttribute('checked', false)
         var wireCheckLabel = document.createElement('label')


### PR DESCRIPTION
When I updated the wireframe system I left in some remnants of the old system which meant that the behavior was correct within one atom, but clicking into a different atom would have unpredictable results. It should now stay consistant
