### PR TITLE
Check to see if any useful information is added to readme

### DIFF
--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -383,6 +383,12 @@ export default class Molecule extends Atom{
         sortableAtomsList.forEach(molecule => {
             generatedReadme = generatedReadme.concat(molecule.requestReadme())
         })
+        
+        //Check to see if any of the children added anything if not, remove the bit we added
+        if(generatedReadme[generatedReadme.length - 1] == '## ' + this.name){
+            generatedReadme.pop()
+        }
+        
         return generatedReadme
     }
     


### PR DESCRIPTION
Every molecule used to make a contribution to the README file of it's name which was really cluttering things up. Now information is only added if at least one of the molecule's children has something to say in the README