### PR TITLE
Constrain atoms to be placed on the screen

### DIFF
--- a/src/js/globalvariables.js
+++ b/src/js/globalvariables.js
@@ -172,6 +172,7 @@ class GlobalVariables{
     * @param {number} width 0-1 
     */
     widthToPixels(width){
+        width = Math.min(width, 1) //Constrain the position to be a max of 1
         let pixels = this.canvas.width * width
         return pixels
     }
@@ -188,6 +189,7 @@ class GlobalVariables{
     * @param {number} width 0-1 
     */
     heightToPixels(height){
+        height = Math.min(height, 1) //Constrain the position of the max value to be 1
         let pixels = this.canvas.height * height
         return pixels
     }


### PR DESCRIPTION
@alzatin instead of the hacky idea I had about making things load correctly for my screen I decided to do things right and constrain the max position to 1. This way old projects will still load, but all the atoms will be down in the far right corner and will need to be re-positioned 
