### PR TITLE
Restrict copy and paste to only work when flow canvas is selected

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -17,7 +17,7 @@
     <link rel="icon" href="https://www.maslowcnc.com/favicon.ico">
  	
 </head>
-<body>
+<body id= "mainBody">
     <div id= doc-frame>
     </div>
      <div id= "headerBar">

--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -136,12 +136,12 @@ window.addEventListener('keydown', e => {
     if (e.keyCode == ctrlKey || e.keyCode == cmdKey) {
         ctrlDown = true
     }
-    if (ctrlDown && e.keyCode == cKey) {
+    if (ctrlDown && e.keyCode == cKey && document.activeElement.id == "mainBody") { //ctrl+c while working in the main body
         GlobalVariables.currentMolecule.nodesOnTheScreen.forEach(molecule => {
             molecule.copySelected()     
         })
     }
-    if (ctrlDown && e.keyCode == vKey) {
+    if (ctrlDown && e.keyCode == vKey && document.activeElement.id == "mainBody") {
         GlobalVariables.currentMolecule.pasteSelected()  
     }
 

--- a/src/index.html
+++ b/src/index.html
@@ -17,7 +17,7 @@
     <link rel="icon" href="https://www.maslowcnc.com/favicon.ico">
  	
 </head>
-<body>
+<body id= "mainBody">
     <div id= doc-frame>
     </div>
      <div id= "headerBar">


### PR DESCRIPTION
We don't want to copy and paste atoms in the background when we're copying and pasting text in the side bar