### PR TITLE
Remove some copy and paste code

### DIFF
--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -308,7 +308,7 @@ export default class Atom {
             this.updateSidebar()
             this.sendToRender()
             clickProcessed = true
-            GlobalVariables.atomsToCopy.push(this.serialize())
+            //GlobalVariables.atomsToCopy.push(this.serialize())  //This is causing an error message when you try to select click on one molecule and then another. We should only be running serialize() when control+c is pressed because the serialize process is super slow
         }
         else if (!GlobalVariables.ctrlDown){
             this.selected = false


### PR DESCRIPTION
@alzatin I'm running into an issue where this line is creating issues when clicking on molecules. I think we should only be serializing if control+c is pressed. I'm taking it out for now, but we should add it back in