### PR TITLE
Fix output displaying when anything else propogates to it

### DIFF
--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -75,8 +75,12 @@ flowCanvas.addEventListener('mousedown', event => {
 
     })
     
-    if(!clickHandledByMolecule){
-        GlobalVariables.currentMolecule.backgroundClick() 
+    
+    if(clickHandledByMolecule){
+        GlobalVariables.currentMolecule.selected = false
+    }
+    else{
+        GlobalVariables.currentMolecule.backgroundClick()
     }
     
     //hide the menu if it is visible

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -182,7 +182,7 @@ export default class Molecule extends Atom{
         }
         
         //If this molecule is selected, send the updated value to the renderer
-        if (this.selected){
+        if(this.selected){
             this.sendToRender()
         }
     }

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -68,8 +68,6 @@ export default class Output extends Atom {
             // if(this.parent.inputs.length == 0 && this.parent.atomType == "GitHubMolecule" && !this.parent.topLevel){
             // this.parent.dumpBuffer(true)
             // }
-            
-            super.updateValue()
         }
     }
     


### PR DESCRIPTION
Every time the final output was updated the display would change to preview that. This makes it so that only happens if you click on the background