### PR TITLE
Fix default text errors

### DIFF
--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -122,12 +122,11 @@ flowCanvas.addEventListener('mouseup', event => {
 * @type {array}
 */
 window.addEventListener('keydown', e => {
-    //makes textarea tag content editable
-    if(e.srcElement.tagName.toLowerCase() == "textarea"){
-        e.srcElement.setAttribute("contenteditable","true")
-    }
     //Prevents default behavior of the browser on canvas to allow for copy/paste/delete
-    if(!e.srcElement.isContentEditable && ['c', 'v', 'Backspace'].includes(e.key)){
+    if((e.srcElement.tagName.toLowerCase() !== "textarea")
+        &&(!e.srcElement.isContentEditable)
+        && ['c', 'v', 'Backspace'].includes(e.key)){
+        console.log("whastff")
         e.preventDefault()
     }
     //Copy /paste listeners

--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -126,7 +126,6 @@ window.addEventListener('keydown', e => {
     if((e.srcElement.tagName.toLowerCase() !== "textarea")
         &&(!e.srcElement.isContentEditable)
         && ['c', 'v', 'Backspace'].includes(e.key)){
-        console.log("whastff")
         e.preventDefault()
     }
     //Copy /paste listeners

--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -122,9 +122,11 @@ flowCanvas.addEventListener('mouseup', event => {
 * @type {array}
 */
 window.addEventListener('keydown', e => {
-
-    if(!event.srcElement.isContentEditable && ['c', 'v', 'Backspace'].includes(e.key)){
-        event.preventDefault()
+    if(e.srcElement.tagName.toLowerCase() == "textarea"){
+        e.srcElement.setAttribute("contenteditable","true")
+    }
+    if(!e.srcElement.isContentEditable && ['c', 'v', 'Backspace'].includes(e.key)){
+        e.preventDefault()
     }
 
     if (e.key == "Control" || e.key == "Meta") {

--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -122,13 +122,15 @@ flowCanvas.addEventListener('mouseup', event => {
 * @type {array}
 */
 window.addEventListener('keydown', e => {
+    //makes textarea tag content editable
     if(e.srcElement.tagName.toLowerCase() == "textarea"){
         e.srcElement.setAttribute("contenteditable","true")
     }
+    //Prevents default behavior of the browser on canvas to allow for copy/paste/delete
     if(!e.srcElement.isContentEditable && ['c', 'v', 'Backspace'].includes(e.key)){
         e.preventDefault()
     }
-
+    //Copy /paste listeners
     if (e.key == "Control" || e.key == "Meta") {
         GlobalVariables.ctrlDown = true
     }      


### PR DESCRIPTION
Maybe Fixes #419 
So, I'm not having the problem with copy/paste in the atom title but I fixed the C problem. I don't know if this is kind of a janky solution but the problem with code is that it creates text areas as it gets written and it seemed easy to test to see if it was a test area. We could combine it all into one if statement to prevent the default but having one that turned the content editable seemed more clear.