### PR TITLE
Check that connector has not already been made before connecting again

### DIFF
--- a/src/js/prototypes/attachmentpoint.js
+++ b/src/js/prototypes/attachmentpoint.js
@@ -288,7 +288,7 @@ export default class AttachmentPoint {
      */ 
     clickUp(x,y){
         this.connectors.forEach(connector => {
-            connector.clickUp(x, y)       
+            connector.clickUp(x, y)
         })
     }
     
@@ -298,8 +298,6 @@ export default class AttachmentPoint {
      * @param {number} y - The y cordinate of the click
      */ 
     clickMove(x,y){
-
-
         let xInPixels = GlobalVariables.widthToPixels(this.x)
         let yInPixels = GlobalVariables.heightToPixels(this.y)
         let radiusInPixels = GlobalVariables.widthToPixels(this.radius)

--- a/src/js/prototypes/connector.js
+++ b/src/js/prototypes/connector.js
@@ -96,7 +96,7 @@ export default class Connector {
             var attachmentMade = false
             GlobalVariables.currentMolecule.nodesOnTheScreen.forEach(molecule => {                      //For every molecule on the screen  
                 molecule.inputs.forEach(attachmentPoint => {                                    //For each of their attachment points
-                    if(attachmentPoint.wasConnectionMade(x,y)){
+                    if(attachmentPoint.wasConnectionMade(x,y) && !attachmentMade){    //Check to make sure we haven't already attached somewhere else
                         attachmentMade = true
                         this.attachmentPoint2 = attachmentPoint
                         attachmentPoint.attach(this)


### PR DESCRIPTION
Fixes #436 

The issue wasn't anything to do with geometry on the wrong input, it was caused by a connector being connected to two different inputs which is obviously not valid. This PR just checks to make sure it hasn't already attached somewhere else before connecting. 

Ultimately we need to make the points expand out in such a way that they never overlap, but that's a trickier issue for another time.
