### PR TITLE
Clicking on atom with no visual input displays nothing

### DIFF
--- a/src/js/display.js
+++ b/src/js/display.js
@@ -588,21 +588,20 @@ export default class Display {
      * @param {object} shape - A jsxcad geometry data set to write to the display. Computation is done in a worker thread
      */ 
     writeToDisplay(shape){
-        if(shape != null){
-            this.displayedGeometry = shape
-            const computeValue = async () => {
-                try {
-                    return await GlobalVariables.render({values: [shape, this.solidDisplay, this.wireDisplay], key: "render"})
-                } catch(err) {
-                    console.warn(err)
-                    return -1
-                }
+        this.displayedGeometry = shape
+        const computeValue = async () => {
+            try {
+                return await GlobalVariables.render({values: [shape, this.solidDisplay, this.wireDisplay], key: "render"})
+            } catch(err) {
+                console.log("Except error")
+                console.warn(err)
+                return -1
             }
-
-            computeValue().then(result => {
-                this.updateDisplayData(result)
-            })
         }
+
+        computeValue().then(result => {
+            this.updateDisplayData(result)
+        })
     }
     
     /**

--- a/src/js/display.js
+++ b/src/js/display.js
@@ -593,7 +593,6 @@ export default class Display {
             try {
                 return await GlobalVariables.render({values: [shape, this.solidDisplay, this.wireDisplay], key: "render"})
             } catch(err) {
-                console.log("Except error")
                 console.warn(err)
                 return -1
             }


### PR DESCRIPTION
This is one part of an update which will make it so clicking on an atom which has no visual representation (for example an equation) will display nothing. 

Previously this would display whatever shape was there from before.

The other half of this change will appear the next time jsxcad is updated.