### PR TITLE
Delete multiple atoms fix

### DIFF
--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -143,24 +143,41 @@ window.addEventListener('keydown', e => {
         && ['c','v', 'Backspace'].includes(e.key)){
         e.preventDefault()
     }
-    //Copy /paste listeners
-    if (e.key == "Control" || e.key == "Meta") {
-        GlobalVariables.ctrlDown = true
-    }      
-    if (GlobalVariables.ctrlDown &&  e.key == "c" && document.activeElement.id == "mainBody") {
-        GlobalVariables.atomsToCopy = []
-        GlobalVariables.currentMolecule.copy()
-    }
-    if (GlobalVariables.ctrlDown &&  e.key == "v" && document.activeElement.id == "mainBody" ) {
-        GlobalVariables.atomsToCopy.forEach(item => {
-            let newAtomID = GlobalVariables.generateUniqueID()
-            item.uniqueID = newAtomID
-            GlobalVariables.currentMolecule.placeAtom(item, true)    
-        })   
-    }
-    if (GlobalVariables.ctrlDown &&  e.key == "s" && document.activeElement.id == "mainBody") {
-        e.preventDefault()
-        GlobalVariables.gitHub.saveProject()
+
+    if (document.activeElement.id == "mainBody"){
+        //Copy /paste listeners
+        if (e.key == "Control" || e.key == "Meta") {
+            GlobalVariables.ctrlDown = true
+        }      
+        if (GlobalVariables.ctrlDown &&  e.key == "c") {
+            GlobalVariables.atomsToCopy = []
+            GlobalVariables.currentMolecule.copy()
+        }
+        if (GlobalVariables.ctrlDown &&  e.key == "v") {
+            GlobalVariables.atomsToCopy.forEach(item => {
+                let newAtomID = GlobalVariables.generateUniqueID()
+                item.uniqueID = newAtomID
+                GlobalVariables.currentMolecule.placeAtom(item, true)    
+            })   
+        }
+        if (GlobalVariables.ctrlDown &&  e.key == "s") {
+            e.preventDefault()
+            GlobalVariables.gitHub.saveProject()
+        }
+        if (e.key == ("Backspace"||"Delete")) {
+            GlobalVariables.atomsToCopy = []
+            GlobalVariables.currentMolecule.copy()
+            console.log(GlobalVariables.atomsToCopy)
+            GlobalVariables.atomsToCopy.forEach(item => {
+                GlobalVariables.currentMolecule.nodesOnTheScreen.forEach(nodeOnTheScreen => {
+                    console.log("delete")
+                    if(nodeOnTheScreen.uniqueID == item.uniqueID){
+
+                        nodeOnTheScreen.deleteNode()
+                    }
+                })
+            })
+        }
     }
     //every time a key is pressed
     GlobalVariables.currentMolecule.nodesOnTheScreen.forEach(molecule => {  

--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -141,7 +141,7 @@ window.addEventListener('keydown', e => {
         && e.srcElement.tagName.toLowerCase() !== ("input")
         &&(!e.srcElement.isContentEditable)
         && ['c','v', 'Backspace'].includes(e.key)){
-        e.preventDefault()
+            e.preventDefault()
     }
 
     if (document.activeElement.id == "mainBody"){
@@ -170,9 +170,7 @@ window.addEventListener('keydown', e => {
             console.log(GlobalVariables.atomsToCopy)
             GlobalVariables.atomsToCopy.forEach(item => {
                 GlobalVariables.currentMolecule.nodesOnTheScreen.forEach(nodeOnTheScreen => {
-                    console.log("delete")
                     if(nodeOnTheScreen.uniqueID == item.uniqueID){
-
                         nodeOnTheScreen.deleteNode()
                     }
                 })
@@ -192,12 +190,10 @@ window.addEventListener('keyup', e => {
     }
 })
 
-
 /* Button to open top menu */
 document.getElementById('straight_menu').addEventListener('mousedown', () => {
     openTopMenu()
 }) 
-
 
 /**
  * Checks if menu is open and changes class to trigger hiding of individual buttons

--- a/src/flowDraw.js
+++ b/src/flowDraw.js
@@ -141,7 +141,7 @@ window.addEventListener('keydown', e => {
         && e.srcElement.tagName.toLowerCase() !== ("input")
         &&(!e.srcElement.isContentEditable)
         && ['c','v', 'Backspace'].includes(e.key)){
-            e.preventDefault()
+        e.preventDefault()
     }
 
     if (document.activeElement.id == "mainBody"){
@@ -166,8 +166,8 @@ window.addEventListener('keydown', e => {
         }
         if (e.key == ("Backspace"||"Delete")) {
             GlobalVariables.atomsToCopy = []
+            //Adds items to the  array that we will use to delete
             GlobalVariables.currentMolecule.copy()
-            console.log(GlobalVariables.atomsToCopy)
             GlobalVariables.atomsToCopy.forEach(item => {
                 GlobalVariables.currentMolecule.nodesOnTheScreen.forEach(nodeOnTheScreen => {
                     if(nodeOnTheScreen.uniqueID == item.uniqueID){

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -435,13 +435,7 @@ export default class Atom {
      */ 
     keyPress(key){ 
 
-        //runs whenever a key is pressed
-        if (['Delete', 'Backspace'].includes(key)){  
-            if(this.selected == true && document.activeElement.id == "mainBody"){
-                //If this atom is selected AND the body is active (meaning we are not typing in a text box)
-                this.deleteNode()
-            }
-        }
+      
         this.inputs.forEach(child => {
             child.keyPress(key)
         })


### PR DESCRIPTION
Fixes #428 

This should make the delete work through an array of selected atoms to be deleted instead of the delete being activated by keypress in each individual atom.