### PR TITLE
Canvas icon draw

### DIFF
--- a/src/js/molecules/BOM.js
+++ b/src/js/molecules/BOM.js
@@ -94,7 +94,7 @@ export default class AddBOMTag extends Atom{
         GlobalVariables.c.beginPath()
         GlobalVariables.c.fillStyle = '#484848'
         GlobalVariables.c.font = `${pixelsRadius/1.5}px Work Sans Bold`
-        GlobalVariables.c.fillText('BOM', pixelsX- pixelsRadius/1.4, pixelsY +this.height/3)
+        GlobalVariables.c.fillText(String.fromCharCode(0x0024,0x0024,0x0024), pixelsX- pixelsRadius/2, pixelsY +this.height/3)
         GlobalVariables.c.fill()
         GlobalVariables.c.closePath()
     }

--- a/src/js/molecules/cutlist.js
+++ b/src/js/molecules/cutlist.js
@@ -55,7 +55,7 @@ export default class CutList extends Atom{
         GlobalVariables.c.beginPath()
         GlobalVariables.c.fillStyle = '#484848'
         GlobalVariables.c.font = `${pixelsRadius}px Work Sans Bold`
-        GlobalVariables.c.fillText(' - - -', GlobalVariables.widthToPixels(this.x- this.radius), GlobalVariables.heightToPixels(this.y)+this.height/3)
+        GlobalVariables.c.fillText(String.fromCharCode(0x2702)+' -', GlobalVariables.widthToPixels(this.x- this.radius/1.5), GlobalVariables.heightToPixels(this.y)+this.height/2)
         GlobalVariables.c.fill()
         GlobalVariables.c.closePath()
     }

--- a/src/js/molecules/extracttag.js
+++ b/src/js/molecules/extracttag.js
@@ -57,7 +57,7 @@ export default class ExtractTag extends Atom{
         GlobalVariables.c.beginPath()
         GlobalVariables.c.fillStyle = '#484848'
         GlobalVariables.c.font = `${pixelsRadius}px Work Sans Bold`
-        GlobalVariables.c.fillText(String.fromCharCode(0x2191,0x2191,0x2191), pixelsX- pixelsRadius/1.2, pixelsY+this.height/2)
+        GlobalVariables.c.fillText(String.fromCharCode(0x2191,0x0023,0x2191), pixelsX- pixelsRadius/1.2, pixelsY+this.height/3)
         GlobalVariables.c.fill()
         GlobalVariables.c.closePath()
     }

--- a/src/js/molecules/extracttag.js
+++ b/src/js/molecules/extracttag.js
@@ -57,7 +57,7 @@ export default class ExtractTag extends Atom{
         GlobalVariables.c.beginPath()
         GlobalVariables.c.fillStyle = '#484848'
         GlobalVariables.c.font = `${pixelsRadius}px Work Sans Bold`
-        GlobalVariables.c.fillText('(#)', pixelsX- pixelsRadius/1.2, pixelsY+this.height/3)
+        GlobalVariables.c.fillText(String.fromCharCode(0x2191,0x2191,0x2191), pixelsX- pixelsRadius/1.2, pixelsY+this.height/2)
         GlobalVariables.c.fill()
         GlobalVariables.c.closePath()
     }

--- a/src/js/molecules/stl.js
+++ b/src/js/molecules/stl.js
@@ -59,8 +59,8 @@ export default class Stl extends Atom {
     
         GlobalVariables.c.beginPath()
         GlobalVariables.c.fillStyle = '#484848'
-        GlobalVariables.c.font = `${pixelsRadius/1.2}px Work Sans Bold`
-        GlobalVariables.c.fillText('STL', GlobalVariables.widthToPixels(this.x- this.radius/1.5), GlobalVariables.heightToPixels(this.y)+this.height/6)
+        GlobalVariables.c.font = `${pixelsRadius/1.2}px Work Sans`
+        GlobalVariables.c.fillText('Stl', GlobalVariables.widthToPixels(this.x- this.radius/1.5), GlobalVariables.heightToPixels(this.y)+this.height/6)
         GlobalVariables.c.fill()
         GlobalVariables.c.closePath()
         

--- a/src/js/molecules/svg.js
+++ b/src/js/molecules/svg.js
@@ -60,8 +60,8 @@ export default class Svg extends Atom {
     
         GlobalVariables.c.beginPath()
         GlobalVariables.c.fillStyle = '#484848'
-        GlobalVariables.c.font = `${pixelsRadius/1.2}px Work Sans Bold`
-        GlobalVariables.c.fillText('SVG', GlobalVariables.widthToPixels(this.x- this.radius/1.3), GlobalVariables.heightToPixels(this.y)+this.height/6)
+        GlobalVariables.c.font = `${pixelsRadius/1.2}px Work Sans`
+        GlobalVariables.c.fillText('Svg', GlobalVariables.widthToPixels(this.x- this.radius/1.4), GlobalVariables.heightToPixels(this.y)+this.height/6)
         GlobalVariables.c.fill()
         GlobalVariables.c.closePath()
         

--- a/src/js/molecules/tag.js
+++ b/src/js/molecules/tag.js
@@ -53,7 +53,7 @@ export default class Tag extends Atom{
         GlobalVariables.c.beginPath()
         GlobalVariables.c.fillStyle = '#484848'
         GlobalVariables.c.font = `${pixelsRadius}px Work Sans Bold`
-        GlobalVariables.c.fillText('#', GlobalVariables.widthToPixels(this.x- this.radius/3), GlobalVariables.heightToPixels(this.y)+this.height/3)
+        GlobalVariables.c.fillText(String.fromCharCode(0x0023), GlobalVariables.widthToPixels(this.x- this.radius/3), GlobalVariables.heightToPixels(this.y)+this.height/3)
         GlobalVariables.c.fill()
         GlobalVariables.c.closePath()
     }


### PR DESCRIPTION
Fixes #474 

I changed some of the tags drawings. I used the hashtag because that seemed like the way to signify a tag. Not super sure what else to use but if you think of another symbol I'm happy to change it.  

<img width="331" alt="Screen Shot 2020-07-26 at 2 59 52 PM" src="https://user-images.githubusercontent.com/47953734/88487234-36634f00-cf51-11ea-9a3f-5c99757f4544.png">

I don't particularly think the rounded corners would look very good but I can totally do it if you feel strongly about it. 😄 
