### PR TITLE
Add timer to project loading

### DIFF
--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -1030,6 +1030,8 @@ export default function GitHubModule(){
      */
     this.loadProject = async function(projectName){
         
+        GlobalVariables.startTime = new Date().getTime();
+        
         if(typeof intervalTimer != undefined){
             clearInterval(intervalTimer) //Turn off auto saving
         }
@@ -1064,8 +1066,6 @@ export default function GitHubModule(){
                 GlobalVariables.circleSegmentSize = rawFile.circleSegmentSize
             }
             
-            intervalTimer = setInterval(() => this.saveProject(), 120000) //Save the project regularly
-            
             if(rawFile.filetypeVersion == 1){
                 GlobalVariables.topLevelMolecule.deserialize(rawFile)
             }
@@ -1082,6 +1082,8 @@ export default function GitHubModule(){
                 document.getElementById("pull_top").style.display = "none"
             }
         })
+        
+        intervalTimer = setInterval(() => this.saveProject(), 120000) //Save the project regularly
     }
     
     this.convertFromOldFormat = function(json){

--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -1030,7 +1030,7 @@ export default function GitHubModule(){
      */
     this.loadProject = async function(projectName){
         
-        GlobalVariables.startTime = new Date().getTime();
+        GlobalVariables.startTime = new Date().getTime()
         
         if(typeof intervalTimer != undefined){
             clearInterval(intervalTimer) //Turn off auto saving

--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -1083,7 +1083,6 @@ export default function GitHubModule(){
             }
         })
         
-        intervalTimer = setInterval(() => this.saveProject(), 120000) //Save the project regularly
     }
     
     this.convertFromOldFormat = function(json){
@@ -1119,6 +1118,13 @@ export default function GitHubModule(){
         }
         
         return projectObject
+    }
+    
+    /** 
+     * Begins the automatic process of saving the project
+     */
+    this.beginAutosave = function(){
+        intervalTimer = setInterval(() => this.saveProject(), 120000) //Save the project regularly
     }
     
     /** 

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -65,10 +65,10 @@ export default class Output extends Atom {
             this.parent.processing = false
             
             if(this.parent.topLevel){
-                const timeToLoad = (new Date().getTime() - GlobalVariables.startTime)/1000;
+                const timeToLoad = (new Date().getTime() - GlobalVariables.startTime)/1000
                 console.warn("Loading finished in " + timeToLoad + " seconds")
                 
-                GlobalVariables.gitHub.beginAutosave();
+                GlobalVariables.gitHub.beginAutosave()
             }
             
             //Remove all the information stored in github molecules with no inputs after they have been computed to save ram

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -67,6 +67,8 @@ export default class Output extends Atom {
             if(this.parent.topLevel){
                 const timeToLoad = (new Date().getTime() - GlobalVariables.startTime)/1000;
                 console.warn("Loading finished in " + timeToLoad + " seconds")
+                
+                GlobalVariables.gitHub.beginAutosave();
             }
             
             //Remove all the information stored in github molecules with no inputs after they have been computed to save ram

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -64,6 +64,11 @@ export default class Output extends Atom {
             this.parent.propogate()
             this.parent.processing = false
             
+            if(this.parent.topLevel){
+                const timeToLoad = (new Date().getTime() - GlobalVariables.startTime)/1000;
+                console.warn("Loading finished in " + timeToLoad + " seconds")
+            }
+            
             //Remove all the information stored in github molecules with no inputs after they have been computed to save ram
             // if(this.parent.inputs.length == 0 && this.parent.atomType == "GitHubMolecule" && !this.parent.topLevel){
             // this.parent.dumpBuffer(true)


### PR DESCRIPTION
Adds a timer to indicate how long each project takes to load. Also prevents the autosave process from beginning until after the project is fully loaded

Fixes #487 
