### PR TITLE
Make JSCADworker binar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 * text=auto
 
 /dist/maslowWorker.js binary
+/dist/JSCADworker.js binary


### PR DESCRIPTION
@alzatin This should mark the worker file as binary to prevent conflicts
