### PR TITLE
Fix saving with nothing connected to the output

### DIFF
--- a/src/js/BOM.js
+++ b/src/js/BOM.js
@@ -50,6 +50,11 @@ export class BOMEntry {
  */ 
 export const extractBomTags = function(assembly){
     
+    //Catch empty input
+    if(assembly == null){
+        return []
+    }
+    
     //Extract all of the tags
     var tags = []
     assembly.forEach(item => {


### PR DESCRIPTION
Fixes the bug where you couldn't save a project with nothing connected to the output
