### PR TITLE
Load tree runs for things even if they aren't connected to the output

### DIFF
--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -583,16 +583,7 @@ export default class Molecule extends Atom{
      */ 
     loadTree(){
         this.nodesOnTheScreen.forEach(node => {
-            if(node.atomType == "Output"){
-                node.loadTree()
-            }
-            
-            if(node.output){
-                if(node.output.connectors.length == 0){
-                    node.loadTree()
-                }
-            }
-            
+            node.loadTree()
         })
         
         this.inputs.forEach(input => {

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -87,7 +87,7 @@ export default class Output extends Atom {
     }
     
     /**
-     * Sets all the input and output values to match their associated atoms.
+     * Sets all the input and output values to match their associated atoms. In this case it sets the path of this and it's parent to be correct.
      */ 
     loadTree(){
         this.path = this.inputs[0].loadTree()

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -732,7 +732,9 @@ export default class Atom {
         this.inputs.forEach(input => {
             input.loadTree()
         })
-        this.output.value = this.path
+        if(this.output){
+            this.output.value = this.path
+        }
         return this.path
     }
     


### PR DESCRIPTION
This makes molecules not connected to the output load with the correct paths. It has the downside that it may run multiple times for somethings, but it's very quick so that's not too much of a hit.