### PR TITLE
Don't display things when doing multi select 

### DIFF
--- a/src/js/molecules/box.js
+++ b/src/js/molecules/box.js
@@ -2,7 +2,7 @@ import Atom from '../prototypes/atom'
 import GlobalVariables from '../globalvariables'
 
 /**
- * This class creates the output atom.
+ * This class is used for selecting multiple atoms. Probably shouldn't be done like this.
  */
 export default class Box extends Atom {
     

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -356,8 +356,6 @@ export default class Atom {
             if(yInPixels >= yIn && yInPixels <= yOut){
                 //this.isMoving = true
                 this.selected = true
-                this.updateSidebar()
-                this.sendToRender()
             }
         }
     }


### PR DESCRIPTION
When selecting multiple atoms they would all be displayed. Now they aren't