### PR TITLE
Make output atoms transparent to molecules

### DIFF
--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -236,12 +236,12 @@ export default class Molecule extends Atom{
                 const values = {key: "simplify", readPath: this.inputPath, writePath: this.path}
                 window.ask(values).then( () => {
                     this.processing = false
-                    this.pushPropogation();
+                    this.pushPropogation()
                 })
             }catch(err){this.setAlert(err)}
         }
         else{
-            this.pushPropogation();
+            this.pushPropogation()
         }
     }
     

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -58,6 +58,11 @@ export default class Molecule extends Atom{
          */
         this.simplify = false
         /** 
+         * A flag to indicate if this molecule is currently processing.
+         * @type {boolean}
+         */
+        this.processing = false //Should be pulled from atom. Docs made me put this here
+        /** 
          * A list of things which should be displayed on the the top level sideBar when in toplevel mode.
          * @type {array}
          */

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -229,11 +229,6 @@ export default class Molecule extends Atom{
      * Called when this molecules value changes
      */ 
     propogate(){
-        
-        
-        console.log("Pushing path: ");
-        console.log(this.path);
-        
         //Set the output nodes with type 'geometry' to be the generated code
         if(this.simplify){
             try{

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -73,6 +73,12 @@ export default class Molecule extends Atom{
          * @type {integer}
          */
         this.toProcess = 0
+        /**
+         * A flag to indicate if this molecule was waiting propagation. If it is it will take place
+         *the next time we go up one level.
+         * @type {number}
+         */
+        this.awaitingPropagationFlag = false
         
         this.setValues(values)
         
@@ -220,29 +226,40 @@ export default class Molecule extends Atom{
     }
     
     /**
-     * Trigger the output to propogate.
+     * Called when this molecules value changes
      */ 
     propogate(){
+        
+        
+        console.log("Pushing path: ");
+        console.log(this.path);
+        
         //Set the output nodes with type 'geometry' to be the generated code
-        if(this.output){
-            if(this.simplify){
-                try{
-                    this.processing = true
-                    const values = {key: "simplify", readPath: this.inputPath, writePath: this.path}
-                    window.ask(values).then( () => {
-                        this.output.setValue(this.path)
-                        this.output.ready = true
-                        if(this.selected){
-                            this.sendToRender()
-                        }
-                        this.processing = false
-                    })
-                }catch(err){this.setAlert(err)}
-            }
-            else{
-                this.output.setValue(this.path)
-                this.output.ready = true
-            }
+        if(this.simplify){
+            try{
+                this.processing = true
+                const values = {key: "simplify", readPath: this.inputPath, writePath: this.path}
+                window.ask(values).then( () => {
+                    this.processing = false
+                    this.pushPropogation();
+                })
+            }catch(err){this.setAlert(err)}
+        }
+        else{
+            this.pushPropogation();
+        }
+    }
+    
+    /**
+     * Called when this molecules value changes
+     */ 
+    pushPropogation(){
+        if(this != GlobalVariables.currentMolecule){
+            this.output.setValue(this.path)
+            this.output.ready = true
+        }
+        else{
+            this.awaitingPropagationFlag = true
         }
         
         //If this molecule is selected, send the updated value to the renderer
@@ -304,7 +321,7 @@ export default class Molecule extends Atom{
         else{  //Changes the path back to be the output atom
             this.nodesOnTheScreen.forEach(atom => {
                 if(atom.atomType == "Output"){
-                    atom.loadTree()
+                    this.path = atom.loadTree()
                 }
             })
         }
@@ -502,18 +519,14 @@ export default class Molecule extends Atom{
                 atom.selected = false
             })
             
-            //Push any changes up to the next level if there are any changes waiting in the output
-            this.nodesOnTheScreen.forEach(atom => {
-                if(atom.atomType == "Output"){
-                    if(atom.awaitingPropagationFlag == true){
-                        this.propogate()
-                        atom.awaitingPropagationFlag = false
-                    }
-                }
-            })
-            
             GlobalVariables.currentMolecule = this.parent //set parent this to be the currently displayed molecule
             GlobalVariables.currentMolecule.backgroundClick()
+            
+            //Push any changes up to the next level if there are any changes waiting in the output
+            if(this.awaitingPropagationFlag == true){
+                this.propogate()
+                this.awaitingPropagationFlag = false
+            }
         }
     }
     
@@ -637,13 +650,22 @@ export default class Molecule extends Atom{
      * Triggers the loadTree process from this molecules output
      */ 
     loadTree(){
-        this.nodesOnTheScreen.forEach(node => {
-            node.loadTree()
+        //We want to walk the tree from this's output and anything which has nothing coming out of it. Basically all the graph end points.
+        
+        this.nodesOnTheScreen.forEach(atom => {
+            //If we have found this molecule's output atom use it to update the path here
+            if(atom.atomType == "Output"){
+                this.path = atom.loadTree()
+                this.inputPath = this.path
+            }
+            //If we have found an atom with nothing connected to it
+            if(atom.output){
+                if(atom.output.connectors.length == 0){
+                    atom.loadTree()
+                }
+            }
         })
         
-        this.inputs.forEach(input => {
-            input.loadTree()
-        })
         this.output.value = this.path
         return this.path
     }

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -2,7 +2,7 @@ import Atom from '../prototypes/atom'
 import GlobalVariables from '../globalvariables'
 
 /**
- * This class creates the output atom.
+ * This class creates the output atom. The goal is that the output atom is fully transparent to the molecule which contains it
  */
 export default class Output extends Atom {
     
@@ -48,12 +48,6 @@ export default class Output extends Atom {
          * @type {number}
          */
         this.radius = 1/75
-        /**
-         * A flag to indicate if this molecule was waiting propagation. If it is it will take place
-         *the next time we go up one level.
-         * @type {number}
-         */
-        this.awaitingPropagationFlag = false
         /** 
          * A description of this atom
          * @type {string}
@@ -71,23 +65,11 @@ export default class Output extends Atom {
     updateValue(){
         if(this.inputs.every(x => x.ready)){
             this.decreaseToProcessCountByOne()
-            this.decreaseToProcessCountByOne()//Called twice to count for the molecule it is in
             
             this.path = this.findIOValue('number or geometry')
             //this.parent.path = this.path
             
-            //If this molecule is the top level or if it is not open, propagate up. Basically prevents propagation for opened molecules
-            if(this.parent.topLevel || this.parent != GlobalVariables.currentMolecule){
-                this.parent.propogate()
-            }
-            else{
-                this.awaitingPropagationFlag = true
-            }
-            
-            //Update the display when the value changes if the parent is selected
-            if(this.parent.selected){
-                this.parent.sendToRender()
-            }
+            this.parent.propogate()  //Propogate passes the updated value on while parent.updateValue is called when one of the molecule inputs changes
         }
     }
     
@@ -96,8 +78,6 @@ export default class Output extends Atom {
      */ 
     loadTree(){
         this.path = this.inputs[0].loadTree()
-        this.parent.path = this.path
-        this.parent.output.value = this.path
         this.value = this.path
         return this.path
     }
@@ -114,17 +94,6 @@ export default class Output extends Atom {
      */
     deleteOutputAtom(){
         super.deleteNode(false)
-    }
-    
-    /**
-     * I am not sure why this function is needed. Did I decide that it was a bad idea to pass the id directly? Should be looked into, can probably be simplified.
-     */ 
-    setID(newID){
-        /**
-         * The unique ID of this atom.
-         * @type {number}
-         */ 
-        this.uniqueID = newID
     }
     
     /**

--- a/src/js/molecules/output.js
+++ b/src/js/molecules/output.js
@@ -48,6 +48,11 @@ export default class Output extends Atom {
          * @type {number}
          */
         this.radius = 1/75
+        /**
+         * This atom's path
+         * @type {string}
+         */
+        this.path = "" //Not sure why documentation made me put this hear instead of pulling it from atom
         /** 
          * A description of this atom
          * @type {string}


### PR DESCRIPTION
The output atom was doing a lot of computation for the molecule which was making things confusing. Now they are transparent and the computation happens in the molecule.
