### PR TITLE
Fix copied BOM tag atoms

### DIFF
--- a/src/js/molecules/BOM.js
+++ b/src/js/molecules/BOM.js
@@ -135,7 +135,7 @@ export default class AddBOMTag extends Atom{
         //Save the readme text to the serial stream
         var valuesObj = super.serialize(values)
         
-        valuesObj.BOMitem = this.BOMitem
+        valuesObj.BOMitem = Object.assign({}, this.BOMitem) //Makes a shallow copy to prevent issues when copy pasting
         
         return valuesObj
         


### PR DESCRIPTION
Copied BOM tags were bringing with them the copied object so one was changed the other would also change