### PR TITLE
Fixes double click detection for code atoms

### DIFF
--- a/src/js/githubOauth.js
+++ b/src/js/githubOauth.js
@@ -1168,6 +1168,7 @@ export default function GitHubModule(){
         //Find out the owners info;
         const user     = repo.data.owner.login
         const repoName = repo.data.name
+        const description = repo.data.description
         //Get the file contents
         let result = await octokit.repos.getContents({
             owner: user,
@@ -1182,6 +1183,8 @@ export default function GitHubModule(){
         }
         
         let rawFile = JSON.parse(atob(result.data.content))
+        
+        rawFile.description = description
         
         if(rawFile.filetypeVersion == 1){
             return rawFile

--- a/src/js/molecules/code.js
+++ b/src/js/molecules/code.js
@@ -112,7 +112,7 @@ export default class Code extends Atom {
         
         var distFromClick = GlobalVariables.distBetweenPoints(x, xInPixels, y, yInPixels)
         
-        if (distFromClick < xInPixels){
+        if (distFromClick < this.radius){
             this.editCode()
             clickProcessed = true
         }


### PR DESCRIPTION
Fixes double click within molecules which contain a code atom. Previously it was always opening the code atom.