### PR TITLE
Make pasted atoms move over

### DIFF
--- a/src/js/molecules/color.js
+++ b/src/js/molecules/color.js
@@ -138,7 +138,7 @@ export default class Color extends Atom {
      * Add the color choice to the object which is saved for this molecule
      */
     serialize(){
-        var superSerialObject = super.serialize(null)
+        var superSerialObject = super.serialize()
         
         //Write the current color selection to the serialized object
         superSerialObject.selectedColorIndex = this.selectedColorIndex

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -200,13 +200,11 @@ export default class Molecule extends Atom{
      * Pushes serialized atoms into array if selected
      */
     copy(){
-        console.log("Copying")
         this.nodesOnTheScreen.forEach(atom => {
             if(atom.selected){
                 GlobalVariables.atomsSelected.push(atom.serialize({x: .03, y: .03}))
             }
         })
-        console.log("Done copying")
     }
     
     /**

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -203,7 +203,7 @@ export default class Molecule extends Atom{
         console.log("Copying")
         this.nodesOnTheScreen.forEach(atom => {
             if(atom.selected){
-                GlobalVariables.atomsSelected.push(atom.serialize({x: 10, y: 10}))
+                GlobalVariables.atomsSelected.push(atom.serialize({x: .03, y: .03}))
             }
         })
         console.log("Done copying")
@@ -560,7 +560,7 @@ export default class Molecule extends Atom{
     /**
      * Generates and returns a object represntation of this molecule and all of its children.
      */
-    serialize(){
+    serialize(offset = {x: 0, y: 0}){
         
         var allAtoms = [] //An array of all the atoms contained in this molecule
         var allConnectors = [] //An array of all the connectors contained in this molecule
@@ -576,7 +576,7 @@ export default class Molecule extends Atom{
             }
         })
         
-        var thisAsObject = super.serialize()    //Do the atom serialization to create an object, then add all the bits of this one to it
+        var thisAsObject = super.serialize(offset)    //Do the atom serialization to create an object, then add all the bits of this one to it
         thisAsObject.topLevel = this.topLevel
         thisAsObject.allAtoms = allAtoms
         thisAsObject.allConnectors = allConnectors

--- a/src/js/molecules/molecule.js
+++ b/src/js/molecules/molecule.js
@@ -200,11 +200,13 @@ export default class Molecule extends Atom{
      * Pushes serialized atoms into array if selected
      */
     copy(){
+        console.log("Copying")
         this.nodesOnTheScreen.forEach(atom => {
             if(atom.selected){
-                GlobalVariables.atomsSelected.push(atom.serialize())
+                GlobalVariables.atomsSelected.push(atom.serialize({x: 10, y: 10}))
             }
         })
+        console.log("Done copying")
     }
     
     /**

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -623,12 +623,10 @@ export default class Atom {
             atomType: this.atomType,
             name: this.name,
             x: this.x + offset.x,
-            y: this.y + offset.y,
+            y: this.y - offset.y,
             uniqueID: this.uniqueID,
             ioValues: ioValues
         }
-        console.log("Serialized to: ")
-        console.log(object)
         return object
     }
     

--- a/src/js/prototypes/atom.js
+++ b/src/js/prototypes/atom.js
@@ -606,8 +606,8 @@ export default class Atom {
     /**
      * Create an object containing the information about this atom that we want to save. 
      */ 
-    serialize(){
-        
+    serialize(offset = {x: 0, y: 0}){
+        //Offsets are used to make copy and pasted atoms move over a little bit
         var ioValues = []
         this.inputs.forEach(io => {
             if (typeof io.getValue() == 'number' || typeof io.getValue() == 'string'){
@@ -622,12 +622,13 @@ export default class Atom {
         var object = {
             atomType: this.atomType,
             name: this.name,
-            x: this.x,
-            y: this.y,
+            x: this.x + offset.x,
+            y: this.y + offset.y,
             uniqueID: this.uniqueID,
             ioValues: ioValues
         }
-        
+        console.log("Serialized to: ")
+        console.log(object)
         return object
     }
     


### PR DESCRIPTION
Copy and pasted atoms are now moved over slightly instead of spawning directly behind their parent 